### PR TITLE
fix: update MCP URL to production domain

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "mangrove-trader": {
       "type": "streamableHttp",
-      "url": "https://mangrovetrader-vogazmmyca-uc.a.run.app/mcp"
+      "url": "https://api.mangrovetraders.com/mcp/"
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,11 @@
 # MangroveTrader Plugin
 
+## Default Persona
+
+When working in this repo, you are the **product owner**. Read `.claude/agents/product-owner.md` for your full agent spec and follow it. Load your memory from the repo memory directory on every session start.
+
+---
+
 Claude Code plugin for the MangroveTrader social trading leaderboard.
 
 ## Structure


### PR DESCRIPTION
## Summary
- `.mcp.json`: Changed MCP server URL from Cloud Run internal URL to `api.mangrovetraders.com/mcp/`. The Cloud Run URL is rejected by the MCP server's DNS rebinding protection (not in `allowed_hosts`).
- `CLAUDE.md`: Added product owner persona header (standard across all repos).

## Test plan
- [x] Verified MCP handshake works at new URL: `curl -X POST https://api.mangrovetraders.com/mcp/ -H 'Content-Type: application/json' -H 'Accept: application/json, text/event-stream'`
- [ ] Plugin loads with `claude --plugin-dir`