### PR TITLE
feat: add marketplace.json for proper plugin install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "mangrove-trader-plugins",
+  "description": "MangroveTrader social trading leaderboard plugin for Claude Code",
+  "owner": {
+    "name": "Mangrove Technologies"
+  },
+  "plugins": [
+    {
+      "name": "mangrove-trader",
+      "description": "Social trading leaderboard. Track trades via @MangroveTrader on Twitter, check stats and performance for free, access rankings and trader search via x402 micropayments (USDC on Base).",
+      "version": "1.0.0",
+      "source": "./",
+      "author": {
+        "name": "Mangrove Technologies"
+      },
+      "category": "productivity",
+      "homepage": "https://mangrovetraders.com"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,7 +5,7 @@
   "author": {
     "name": "Mangrove Technologies"
   },
-  "repository": "https://github.com/MangroveTechnologies/mangrove-trader-plugin",
+  "repository": "https://github.com/MangroveTechnologies/mangrove-trader-plugins",
   "keywords": [
     "trading",
     "leaderboard",

--- a/README.md
+++ b/README.md
@@ -4,15 +4,18 @@ Social trading leaderboard plugin. Track trades via [@MangroveTrader](https://tw
 
 ## Install
 
+From source (GitHub):
+
 ```bash
+git clone https://github.com/MangroveTechnologies/mangrove-trader-plugins.git
+claude plugin marketplace add ./mangrove-trader-plugins
 claude plugin install mangrove-trader
 ```
 
-Or install from source:
+Or load for a single session without installing:
 
 ```bash
-git clone https://github.com/MangroveTechnologies/mangrove-trader-plugin.git
-claude plugin install ./mangrove-trader-plugin
+claude --plugin-dir ./mangrove-trader-plugins
 ```
 
 ## Tools


### PR DESCRIPTION
## Summary

Adds `marketplace.json` so the plugin can be properly installed via `claude plugin marketplace add` + `claude plugin install`.

Previously there was no install path other than `--plugin-dir`. Now:

```bash
# From GitHub
git clone https://github.com/MangroveTechnologies/mangrove-trader-plugins.git
claude plugin marketplace add ./mangrove-trader-plugins
claude plugin install mangrove-trader

# Or single-session
claude --plugin-dir ./mangrove-trader-plugins
```

Also fixes:
- `plugin.json` repo URL (was singular `mangrove-trader-plugin`, now plural)
- README install instructions updated

Tested: `claude plugin install mangrove-trader` succeeds after marketplace add.