### PR TITLE
feat: marketplace submission prep

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "mangrove-trader-plugins",
+  "name": "mangrove-trader-plugin",
   "description": "MangroveTrader social trading leaderboard plugin for Claude Code",
   "owner": {
     "name": "Mangrove Technologies"
@@ -9,7 +9,7 @@
     {
       "name": "mangrove-trader",
       "description": "Social trading leaderboard. Track trades via @MangroveTrader on Twitter, check stats and performance for free, access rankings and trader search via x402 micropayments (USDC on Base).",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "source": "./",
       "author": {
         "name": "Mangrove Technologies"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,7 +5,10 @@
   "author": {
     "name": "Mangrove Technologies"
   },
-  "repository": "https://github.com/MangroveTechnologies/mangrove-trader-plugins",
+  "homepage": "https://mangrovetraders.com",
+  "repository": "https://github.com/MangroveTechnologies/mangrove-trader-plugin",
+  "license": "MIT",
+  "category": "productivity",
   "keywords": [
     "trading",
     "leaderboard",
@@ -13,6 +16,9 @@
     "social-trading",
     "micropayments",
     "base",
-    "usdc"
+    "usdc",
+    "mcp",
+    "twitter",
+    "crypto"
   ]
 }

--- a/.claude/agents/product-owner.md
+++ b/.claude/agents/product-owner.md
@@ -1,0 +1,74 @@
+---
+name: product-owner
+model: claude-opus-4-6
+description: Product owner for mangrove-trader-plugin. Owns the product backlog, defines acceptance criteria, makes scope decisions, and drives toward business outcomes for the MangroveTrader plugin suite. Invoke for any work in this repo.
+---
+
+# Product Owner -- mangrove-trader-plugin
+
+You are the product owner for the mangrove-trader-plugin repository. You own the product backlog and are accountable for maximizing the value delivered by this repo. Your responsibilities: backlog prioritization by business value, defining acceptance criteria for every work item, making scope decisions for each iteration, communicating status and trade-offs to the VP of Engineering, guarding the product vision, and driving toward outcomes -- not just green builds, but shipping the right thing.
+
+**Repo**: MangroveTechnologies/mangrove-trader-plugin
+**Stack**: TypeScript
+**Domain**: Claude Code + OpenClaw plugins for MangroveTrader. 5 skills: track-trade, portfolio, performance, leaderboard, search. v1.0.0 fully compatible.
+
+## First Actions (Every Invocation)
+
+1. `cd /home/darrahts/development/Dropbox/alpha-delta/mangrove/mangrove-trader-plugin`
+2. Read `CLAUDE.md` if it exists, otherwise read `README.md`
+3. `gh issue list --repo MangroveTechnologies/mangrove-trader-plugin --limit 20`
+4. `gh pr list --repo MangroveTechnologies/mangrove-trader-plugin`
+5. `gh run list --repo MangroveTechnologies/mangrove-trader-plugin --limit 5`
+6. `git log --oneline -10`
+
+## Key Context
+
+- 5 skills that consume MangroveTrader API
+- v1.0.0 shipped, fully compatible with MangroveTrader
+- Public repo
+- Currently 0 open issues
+
+## Work Delegation
+
+To delegate to a specialized agent:
+Agent definitions at `mangrove/.claude/agents/` are auto-registered as routable subagent_types.
+Use the named subagent_type directly: `Agent(subagent_type="<agent-name>", prompt="<repo context + task>")`
+
+| Task Type | Agent Definition | File |
+|-----------|-----------------|------|
+| TypeScript skill implementations | backend-developer | `backend-developer.md` |
+| jest/vitest tests | test-engineer | `test-engineer.md` |
+| Code review, convention compliance | code-review | `code-review.md` |
+
+Always pass the agent spec verbatim as the first part of the prompt, followed by repo path, branch name, and the specific task with acceptance criteria.
+
+## Quality Gates
+
+- Feature branch + PR workflow
+- TypeScript compiles
+- CI green after push
+- Plugin skills remain compatible with MangroveTrader API
+
+## Memory
+
+This product owner maintains persistent memory at:
+`~/.claude/projects/-home-darrahts-development-Dropbox-alpha-delta-mangrove/memory/repos/mangrove-trader-plugin/`
+
+**On every invocation:**
+1. Read `REPO_MEMORY.md` to load context from prior sessions
+2. After completing work, update memory files with decisions made and outcomes
+
+**Memory files** (create as needed):
+- `REPO_MEMORY.md` -- index of all memory for this repo
+- `status.md` -- current state, recent decisions, blockers
+- `issues.md` -- issue triage decisions, priority rationale
+- `delegation.md` -- what was delegated to whom, outcomes
+- `architecture.md` -- repo-specific architecture decisions
+
+Never duplicate information already in the main portfolio MEMORY.md.
+
+## Constraints
+
+- NEVER push without explicit user approval.
+- NEVER declare done until CI passes.
+- Must stay in sync with MangroveTrader API changes.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,25 @@
 # MangroveTrader Plugin for Claude Code
 
-Social trading leaderboard plugin. Track trades via [@MangroveTrader](https://twitter.com/MangroveTrader) on Twitter, check your stats and performance for free, and access full rankings and trader search via x402 micropayments.
+[MangroveTrader](https://mangrovetraders.com) is a social trading leaderboard where traders post trades on Twitter, positions are tracked against real market data, and performance is scored daily.
+
+This plugin connects Claude Code to the MangroveTrader MCP server, giving you 12 slash commands and 9 MCP tools for stats, leaderboard, trade history, and more.
+
+**Website:** [mangrovetraders.com](https://mangrovetraders.com)
+**Twitter:** [@MangroveTrader](https://twitter.com/MangroveTrader)
+**Source:** [github.com/MangroveTechnologies/mangrove-trader-plugin](https://github.com/MangroveTechnologies/mangrove-trader-plugin)
 
 ## Install
 
-From source (GitHub):
-
 ```bash
-git clone https://github.com/MangroveTechnologies/mangrove-trader-plugins.git
-claude plugin marketplace add ./mangrove-trader-plugins
+git clone https://github.com/MangroveTechnologies/mangrove-trader-plugin.git
+claude plugin marketplace add ./mangrove-trader-plugin
 claude plugin install mangrove-trader
 ```
 
 Or load for a single session without installing:
 
 ```bash
-claude --plugin-dir ./mangrove-trader-plugins
+claude --plugin-dir ./mangrove-trader-plugin
 ```
 
 ## Commands
@@ -39,13 +43,16 @@ All commands are prefixed with `/mt-`:
 
 ## MCP Tools
 
-The plugin connects to MangroveTrader's MCP server. 9 tools available.
+The plugin connects to MangroveTrader's MCP server at `https://api.mangrovetraders.com/mcp/`. 9 tools available:
 
 | Tool | Access | Price |
 |------|--------|-------|
 | `trader_my_stats` | Free | -- |
 | `trader_performance_report` | Free | -- |
 | `trader_last_trade` | Free | -- |
+| `trader_cancel_last` | Free | -- |
+| `trader_watch` | Free | -- |
+| `trader_unwatch` | Free | -- |
 | `trader_get_leaderboard` | x402 | $0.25+ USDC |
 | `trader_search_trader` | x402 | $0.02 USDC |
 | `trader_get_trade_history` | x402 | $0.01/3 trades |
@@ -55,16 +62,23 @@ The plugin connects to MangroveTrader's MCP server. 9 tools available.
 1. Tweet your trade to **@MangroveTrader** on Twitter (use `/mt-track` to compose)
 2. A Grok-powered agent parses your trade and tracks the position
 3. Positions are marked-to-market against real prices every 5 minutes
-4. Scoring runs daily at midnight UTC: 50% return, 30% consistency (Sharpe), 20% risk (max drawdown)
+4. Scoring runs daily at midnight UTC
 
 ### Tweet Format
 
 ```
-enter long 100 AAPL @ 185.50       # Equities
-enter long 2.5 BTC @ 64000         # Crypto
-enter short 5 ES @ 5250            # Futures
-enter long 10 AAPL 190C 2026-04-18 @ 3.50  # Options
+@MangroveTrader long 100 AAPL @ 185.50       # Equities
+@MangroveTrader enter long 2.5 BTC @ 64000   # Crypto
+@MangroveTrader exit short 5 ES @ 5250       # Futures
 ```
+
+### Scoring
+
+| Component | Weight | Metric |
+|-----------|--------|--------|
+| Return | 50% | Total return percentage |
+| Consistency | 30% | Sharpe ratio |
+| Risk Management | 20% | Max drawdown (lower is better) |
 
 ## x402 Payments
 
@@ -76,8 +90,26 @@ Paid tools use the [x402 protocol](https://www.x402.org/) for micropayments:
 - **Safety:** You are never charged if data retrieval fails
 - **API key bypass:** `X-API-Key` header on REST endpoints skips x402
 
-For agents with wallets: use the x402 SDK or MangroveMarkets TypeScript SDK.
+For agents with wallets: use the x402 SDK or MangroveMarkets TypeScript SDK to sign payments.
 For Claude Code users without wallets: free tools work without payment. Paid data available via REST API with an API key.
+
+## Security and Privacy
+
+This plugin connects to a remote MCP server hosted on GCP Cloud Run. Here is what it does and does not do:
+
+- **Data accessed:** Public trading data (scores, ranks, trade history). No personally identifiable information.
+- **No credentials stored:** The plugin does not store, transmit, or require any API keys, wallet keys, or passwords.
+- **Payment confirmation:** Paid tools always show the price and ask for confirmation before any charge. You are never charged without explicit consent.
+- **x402 payments:** All payments settle on Base mainnet (USDC). Transaction hashes are returned for on-chain verification.
+- **Server source code:** The MCP server source is public at [github.com/MangroveTechnologies/MangroveTrader](https://github.com/MangroveTechnologies/MangroveTrader).
+- **No tracking:** The plugin does not track usage, analytics, or telemetry beyond what the MCP server logs for rate limiting.
+
+## Documentation
+
+- [User Guide](docs/user-guide.md) -- Step-by-step walkthrough of every feature
+- [MangroveTrader Website](https://mangrovetraders.com) -- Landing page with full docs
+- [API Reference](https://mangrovetraders.com/docs/api-reference) -- REST and MCP endpoint details
+- [Twitter Validation Checklist](https://github.com/MangroveTechnologies/MangroveTrader/blob/main/docs/reports/twitter-validation-checklist.md) -- Test every feature on Twitter
 
 ## License
 

--- a/docs/plans/marketplace-submission.md
+++ b/docs/plans/marketplace-submission.md
@@ -1,0 +1,113 @@
+# MangroveTrader Plugin -- Marketplace Submission Plan
+
+Prepare the plugin for submission to the official Claude Code plugin directory.
+
+## Step 1: Rename GitHub Repo
+
+Rename `mangrove-trader-plugin` -> `mangrove-trader-plugin` (singular).
+
+**How:** GitHub Settings > General > Repository name > Rename. GitHub auto-redirects the old URL.
+
+**Impact:** Every reference to the repo URL needs updating across both repos.
+
+### References to update in mangrove-trader-plugin (this repo):
+
+| File | What to change |
+|------|----------------|
+| `.claude-plugin/plugin.json` | `repository` URL |
+| `.claude-plugin/marketplace.json` | `name` field |
+| `README.md` | clone URL, marketplace add command, plugin-dir path |
+| `CLAUDE.md` | Any repo name references |
+| `docs/user-guide.md` | clone URL, marketplace add, plugin-dir |
+| `docs/plans/mt-command-parity.md` | repo name references |
+
+### References to update in MangroveTrader:
+
+| File | What to change |
+|------|----------------|
+| `site/src/components/Nav.astro` | 2 GitHub links |
+| `site/src/components/Footer.astro` | GitHub link |
+| `site/src/components/Hero.astro` | GitHub link |
+| `site/src/pages/docs/plugins.astro` | clone URL, marketplace add, plugin-dir, architecture tree, repo link |
+| `site/src/pages/docs/index.astro` | GitHub link |
+| `site/src/layouts/Docs.astro` | GitHub link |
+| `docs/endpoints.md` | Plugin reference |
+| `docs/user-stories.md` | Plugin reference |
+| `docs/reports/2026-03-22-payment-surface-audit.md` | Plugin repo URL |
+
+### References to update in portfolio:
+
+| File | What to change |
+|------|----------------|
+| `memory/MEMORY.md` | Repo name in active list, memory path |
+| `memory/repos/mangrove-trader-plugin/REPO_MEMORY.md` | Rename directory? Or leave as-is (memory is internal) |
+| `CLAUDE.md` (portfolio root) | Project table |
+| `.mcp.json` (portfolio root) | No change needed (URL is api.mangrovetraders.com, not repo) |
+
+## Step 2: Apply Community Lessons
+
+Based on research of published plugins and community feedback:
+
+### 2a. Structure verification
+
+- [x] `plugin.json` is in `.claude-plugin/` (correct)
+- [x] `commands/`, `skills/`, `hooks/` are at plugin root (correct -- common mistake is nesting inside .claude-plugin/)
+- [x] `marketplace.json` is in `.claude-plugin/` (correct)
+- [ ] `marketplace.json` version should match `plugin.json` version (currently 1.0.0 vs 2.0.0 -- fix)
+
+### 2b. plugin.json improvements
+
+- [ ] Add `homepage` field: `"homepage": "https://mangrovetraders.com"`
+- [ ] Add `license` field: `"license": "MIT"`
+- [ ] Add `category` field: `"category": "productivity"` (matches marketplace.json)
+- [ ] Verify `keywords` are discoverable terms people would search for
+
+### 2c. README improvements
+
+- [ ] Add link to MangroveTrader website at the top
+- [ ] Add link to the MangroveTrader Twitter account
+- [ ] Add "What is MangroveTrader?" section before Install (don't assume reader knows)
+- [ ] Add badges (optional but common in published plugins)
+- [ ] Add screenshot or example output (if practical)
+
+### 2d. Transparency for MCP server review
+
+Since our plugin connects to a remote MCP server, reviewers will want to know:
+- [ ] What data the MCP server accesses (trading data, no PII)
+- [ ] What the payment flow does (x402 micropayments, user must confirm)
+- [ ] That no credentials are stored or transmitted by the plugin
+- [ ] That the MCP server source code is public (MangroveTrader repo)
+
+Add a "Security & Privacy" section to README covering these points.
+
+### 2e. Code vs Claude boundary (Pierce Lamb lesson)
+
+Review SKILL.md to ensure:
+- [ ] Instructions that can be explicit (tool params, error handling) ARE explicit
+- [ ] LLM judgment is only used where needed (interpreting user intent, presenting results)
+- [ ] No vague "figure it out" instructions
+
+## Step 3: Submit
+
+1. Verify all changes are committed and pushed
+2. Go to `claude.ai/settings/plugins/submit` or `platform.claude.com/plugins/submit`
+3. Submit the plugin with:
+   - Repository URL: `https://github.com/MangroveTechnologies/mangrove-trader-plugin`
+   - Plugin name: `mangrove-trader`
+   - Category: productivity
+4. Wait for automated review
+5. If accepted, users can install with: `claude plugin install mangrove-trader`
+
+## Step 4: Also Submit to Community Directories
+
+- [claudemarketplaces.com](https://claudemarketplaces.com/) -- community directory
+- [claude-plugins.dev](https://claude-plugins.dev/) -- community registry
+- [awesome-claude-code](https://github.com/hesreallyhim/awesome-claude-code) -- curated list (submit PR)
+
+## Execution Order
+
+1. Rename the GitHub repo first (all URL updates depend on this)
+2. Update all references in both repos (one PR each)
+3. Apply plugin.json and README improvements (same PR as #2 in plugin repo)
+4. Submit to Anthropic
+5. Submit to community directories

--- a/docs/plans/mt-command-parity.md
+++ b/docs/plans/mt-command-parity.md
@@ -410,10 +410,10 @@ Final version with all 9 tools listed.
 
 | Phase | Subagent | Repo |
 |-------|----------|------|
-| 1 | `backend-developer` | mangrove-trader-plugins |
+| 1 | `backend-developer` | mangrove-trader-plugin |
 | 2 | `backend-developer` (via MangroveTrader product owner) | MangroveTrader |
-| 3 | `backend-developer` | mangrove-trader-plugins |
-| 4 | `backend-developer` | mangrove-trader-plugins |
+| 3 | `backend-developer` | mangrove-trader-plugin |
+| 4 | `backend-developer` | mangrove-trader-plugin |
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -14,14 +14,14 @@ Step-by-step guide to using every MangroveTrader feature through the Claude Code
 ## Install
 
 ```bash
-git clone https://github.com/MangroveTechnologies/mangrove-trader-plugins.git
-claude plugin marketplace add ./mangrove-trader-plugins
+git clone https://github.com/MangroveTechnologies/mangrove-trader-plugin.git
+claude plugin marketplace add ./mangrove-trader-plugin
 claude plugin install mangrove-trader
 ```
 
 Or for a single session:
 ```bash
-claude --plugin-dir ./mangrove-trader-plugins
+claude --plugin-dir ./mangrove-trader-plugin
 ```
 
 Start Claude Code and verify the plugin loaded:


### PR DESCRIPTION
## Summary

Prepares the plugin for submission to the official Claude Code plugin directory.

**Repo renamed:** `mangrove-trader-plugins` -> `mangrove-trader-plugin` (singular)

**Changes:**
- All repo name references updated across all files
- `plugin.json`: added `homepage`, `license`, `category`, expanded `keywords` (mcp, twitter, crypto)
- `marketplace.json`: version synced to 2.0.0, name corrected
- `README.md`: full rewrite -- "What is MangroveTrader" intro, website/Twitter links, Security & Privacy section, documentation links
- Added marketplace submission plan at `docs/plans/marketplace-submission.md`
- Product owner agent updated with new repo name

**Community lessons applied:**
- Structure verified (commands/skills/hooks at root, only plugin.json in .claude-plugin/)
- marketplace.json version matches plugin.json (2.0.0)
- Transparent about remote MCP server (what data, no credentials, payment confirmation, source is public)
- Keywords expanded for discoverability

**After merge:** Submit via `claude.ai/settings/plugins/submit`