### PR TITLE
fix: correct hooks.json format for plugin loader

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,7 +1,7 @@
 {
-  "hooks": [
+  "UserPromptSubmit": [
     {
-      "event": "user-prompt-submit",
+      "matcher": "",
       "hooks": [
         {
           "type": "command",


### PR DESCRIPTION
## Summary
- Fix hooks.json schema: use PascalCase event key (`UserPromptSubmit`) at top level instead of wrapped `"hooks"` array with `"event"` field
- Fixes plugin load error: `Hook load failed: expected record, received array`

## Test plan
- [ ] Reinstall plugin, verify it loads without error
- [ ] `/mt-help` works and context hook fires on prompt submit