### PR TITLE
fix: correct hooks.json schema (wrap in outer hooks key)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,13 +1,15 @@
 {
-  "UserPromptSubmit": [
-    {
-      "matcher": "",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "cat hooks/context.json"
-        }
-      ]
-    }
-  ]
+  "description": "MangroveTrader context hook — injects available commands and tools on each prompt",
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat hooks/context.json"
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Plugin hooks.json must use `{ "hooks": { "EventName": [...] } }` format, not bare `{ "EventName": [...] }`
- Matched schema from official Claude Code plugins (e.g. ralph-loop)
- Fixes persistent "expected record, received array" load error

## Test plan
- [x] Updated cache locally, `claude plugin list` shows Status: enabled
- [x] Fresh install loads without error
- [x] `/mt-help` works in new session