### PR TITLE
Fix mt-report default timeframe from 30d to all_time

### DIFF
--- a/commands/mt-report.md
+++ b/commands/mt-report.md
@@ -10,7 +10,7 @@ Get a detailed performance report for a trader.
 ## Steps
 
 1. Use the handle from `/mt-set-handle` if set. Otherwise ask for Twitter handle.
-2. Ask for timeframe if not specified. Valid: `daily`, `weekly`, `monthly`, `all_time`, `30d`, `7d`. Default: `30d`
+2. Ask for timeframe if not specified. Valid: `daily`, `weekly`, `monthly`, `all_time`, `30d`, `7d`. Default: `all_time`
 3. Call the `trader_performance_report` MCP tool with `twitter_handle` and `timeframe`
 4. **If MCP tool is not available**, fall back to REST: `POST https://api.mangrovetraders.com/api/v1/trader/performance_report` with `{"twitter_handle": "<handle>", "timeframe": "<timeframe>"}`
 5. Present results with scoring breakdown:


### PR DESCRIPTION
## Summary
- Default timeframe in `/mt-report` skill changed from `30d` to `all_time` to match server-side fix (30d was causing 500 as the default)

## Test plan
- [ ] Run `/mt-report` without specifying a timeframe -- should use `all_time` and return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)