### PR TITLE
feat: add x402 auto-signing hook and update docs

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mangrove-trader",
   "description": "Social trading leaderboard. Track trades via @MangroveTrader on Twitter, check stats and performance for free, access rankings and trader search via x402 micropayments (USDC on Base).",
-  "version": "2.0.3",
+  "version": "2.0.5",
   "author": {
     "name": "Mangrove Technologies"
   },

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [MangroveTrader](https://mangrovetraders.com) is a social trading leaderboard where traders post trades on Twitter, positions are tracked against real market data, and performance is scored daily.
 
-This plugin connects Claude Code to the MangroveTrader MCP server, giving you 13 slash commands and 9 MCP tools for stats, leaderboard, trade history, and more.
+This plugin connects Claude Code to the MangroveTrader MCP server, giving you 13 slash commands and 10 MCP tools for stats, leaderboard, trade history, and more.
 
 **Website:** [mangrovetraders.com](https://mangrovetraders.com)
 **Twitter:** [@MangroveTrader](https://twitter.com/MangroveTrader)
@@ -44,19 +44,20 @@ All commands are prefixed with `/mt-`:
 
 ## MCP Tools
 
-The plugin connects to MangroveTrader's MCP server at `https://api.mangrovetraders.com/mcp/`. 9 tools available:
+The plugin connects to MangroveTrader's MCP server at `https://api.mangrovetraders.com/mcp/`. 10 tools available:
 
-| Tool | Access | Price |
-|------|--------|-------|
-| `trader_my_stats` | Free | -- |
-| `trader_performance_report` | Free | -- |
-| `trader_last_trade` | Free | -- |
-| `trader_cancel_last` | Free | -- |
-| `trader_watch` | Free | -- |
-| `trader_unwatch` | Free | -- |
-| `trader_get_leaderboard` | x402 | $0.25+ USDC (top 5 free on Twitter) |
-| `trader_search_trader` | x402 | $0.02 USDC |
-| `trader_get_trade_history` | Free / x402 | Free (own) / $0.01/3 trades (others) |
+| Tool | Access | Price | Notes |
+|------|--------|-------|-------|
+| `trader_login` | Free | -- | Start X OAuth 2.0 — returns a verification URL |
+| `trader_my_stats` | Free | -- | Requires `auth_token` (MT_AUTH_TOKEN) |
+| `trader_performance_report` | Free | -- | Requires `auth_token` |
+| `trader_last_trade` | Free | -- | Public — accepts any `twitter_handle` |
+| `trader_cancel_last` | Free | -- | Requires `auth_token` |
+| `trader_watch` | Free | -- | Requires `auth_token` |
+| `trader_unwatch` | Free | -- | Requires `auth_token` |
+| `trader_get_leaderboard` | x402 | $0.25+ USDC | Top 5 free on Twitter |
+| `trader_search_trader` | x402 | $0.02 USDC | -- |
+| `trader_get_trade_history` | Free / x402 | Free (own w/ auth_token) / $0.01/3 trades (others) | -- |
 
 ## How Trading Works
 
@@ -99,7 +100,8 @@ For Claude Code users without wallets: free tools work without payment. Paid dat
 This plugin connects to a remote MCP server hosted on GCP Cloud Run. Here is what it does and does not do:
 
 - **Data accessed:** Public trading data (scores, ranks, trade history). No personally identifiable information.
-- **No credentials stored:** The plugin does not store, transmit, or require any API keys, wallet keys, or passwords.
+- **Identity verification:** Free tools that write or read your account (`trader_my_stats`, `trader_cancel_last`, `trader_watch`, `trader_unwatch`) require a session token obtained via X OAuth 2.0. Use `/mt-set-handle` to authenticate — your handle is verified server-side and cannot be spoofed.
+- **No credentials stored:** The plugin does not store, transmit, or require any API keys, wallet keys, or passwords. The session token (`MT_AUTH_TOKEN`) is stored only in your local environment.
 - **Payment confirmation:** Paid tools always show the price and ask for confirmation before any charge. You are never charged without explicit consent.
 - **x402 payments:** All payments settle on Base mainnet (USDC). Transaction hashes are returned for on-chain verification.
 - **Server source code:** The MCP server source is public at [github.com/MangroveTechnologies/MangroveTrader](https://github.com/MangroveTechnologies/MangroveTrader).

--- a/commands/mt-history.md
+++ b/commands/mt-history.md
@@ -15,7 +15,11 @@ View a trader's complete trade history. Your own history is free.
 4. **If looking up someone else's history**: call `trader_get_trade_history` WITHOUT `payment` parameter first. Server returns PAYMENT_REQUIRED with total trades and computed price.
 5. Present: "X trades available, cost is $Y USDC. Proceed?"
 6. **If payment capability available**: sign x402 payment, call again WITH `payment`, present trade list (action, symbol, asset class, quantity, price, timestamp)
-7. **If no payment capability**: suggest `/mt-last` (free, shows most recent trade only) or the REST API with an API key
+7. **If no payment capability**: tell the user this tool requires x402 payment signing with an EVM wallet holding USDC on Base. Ask them to provide their EVM wallet private key. Once provided, persist it for future sessions using the platform-appropriate method, then set it in the current session and retry from step 4:
+   - **macOS**: append `export MT_WALLET_PRIVATE_KEY=<key>` to `~/.zshenv`
+   - **Linux**: append `export MT_WALLET_PRIVATE_KEY=<key>` to `~/.bashrc` (or `~/.profile` for login shells)
+   - **Windows (PowerShell)**: run `[System.Environment]::SetEnvironmentVariable('MT_WALLET_PRIVATE_KEY', '<key>', 'User')` to persist at user level; also set in current session with `$env:MT_WALLET_PRIVATE_KEY='<key>'`
+   - If the user does not have a wallet, suggest `/mt-last` (free, shows most recent trade only) or the REST API with an API key
 
 ## Pricing
 

--- a/commands/mt-leaderboard.md
+++ b/commands/mt-leaderboard.md
@@ -26,8 +26,11 @@ This is an x402 paid tool. The agent or user must pay in USDC on Base to access 
    - Sign the payment using the x402 protocol against the requirements
    - Call `trader_get_leaderboard` again WITH the signed `payment` parameter
    - Present the leaderboard: rank, handle, score, return %
-7. **If no payment capability**:
-   - Tell the user the price and suggest alternatives:
+7. **If no payment capability**: tell the user this tool requires x402 payment signing with an EVM wallet holding USDC on Base. Ask them to provide their EVM wallet private key. Once provided, persist it for future sessions using the platform-appropriate method, then set it in the current session and retry from step 3:
+   - **macOS**: append `export MT_WALLET_PRIVATE_KEY=<key>` to `~/.zshenv`
+   - **Linux**: append `export MT_WALLET_PRIVATE_KEY=<key>` to `~/.bashrc` (or `~/.profile` for login shells)
+   - **Windows (PowerShell)**: run `[System.Environment]::SetEnvironmentVariable('MT_WALLET_PRIVATE_KEY', '<key>', 'User')` to persist at user level; also set in current session with `$env:MT_WALLET_PRIVATE_KEY='<key>'`
+   - If the user does not have a wallet, suggest alternatives:
      - Own rank is always free via `/mt-stats`
      - Use the REST API at `https://api.mangrovetraders.com/api/x402/leaderboard` with an API key (X-API-Key header bypasses payment)
      - Daily top 10 posted on @MangroveTrader Twitter

--- a/commands/mt-search.md
+++ b/commands/mt-search.md
@@ -17,7 +17,10 @@ This is an x402 paid tool ($0.02 USDC on Base).
 4. Server returns PAYMENT_REQUIRED ($0.02 USDC).
 5. Present the price and ask to confirm.
 6. **If payment capability available**: sign x402 payment, call again WITH `payment`, present results (handle, display name, score, rank, trade count, qualified status).
-7. **If no payment capability**: suggest `/mt-stats <handle>` (free, if they know the exact handle).
+7. **If no payment capability**: tell the user this tool requires x402 payment signing with an EVM wallet holding USDC on Base. Ask them to provide their EVM wallet private key. Once provided, persist it for future sessions using the platform-appropriate method, then set it in the current session and retry from step 3:
+   - **macOS**: append `export MT_WALLET_PRIVATE_KEY=<key>` to `~/.zshenv`
+   - **Linux**: append `export MT_WALLET_PRIVATE_KEY=<key>` to `~/.bashrc` (or `~/.profile` for login shells)
+   - **Windows (PowerShell)**: run `[System.Environment]::SetEnvironmentVariable('MT_WALLET_PRIVATE_KEY', '<key>', 'User')` to persist at user level; also set in current session with `$env:MT_WALLET_PRIVATE_KEY='<key>'`
 
 ## Parameters
 

--- a/commands/mt-set-handle.md
+++ b/commands/mt-set-handle.md
@@ -14,7 +14,10 @@ Your handle is derived from your verified session token — not from a string yo
 1. Check the `MT_AUTH_TOKEN` environment variable.
 2. If `MT_AUTH_TOKEN` is set, call `trader_my_stats` with `auth_token` to resolve and confirm the verified handle.
 3. Confirm: "Verified as @{handle}. All commands will use this identity."
-4. If `MT_AUTH_TOKEN` is not set, call `trader_login` to get a verification URL. Tell the user to authenticate with X, then set the token in their environment and run `/mt-set-handle` again.
+4. If `MT_AUTH_TOKEN` is not set, call `trader_login` to get a verification URL. Tell the user to authenticate with X. Once they provide their token, persist it for future sessions using the platform-appropriate method, then set it in the current session and run `/mt-set-handle` again:
+   - **macOS**: append `export MT_AUTH_TOKEN=<token>` to `~/.zshenv`
+   - **Linux**: append `export MT_AUTH_TOKEN=<token>` to `~/.bashrc` (or `~/.profile` for login shells)
+   - **Windows (PowerShell)**: run `[System.Environment]::SetEnvironmentVariable('MT_AUTH_TOKEN', '<token>', 'User')` to persist at user level; also set in current session with `$env:MT_AUTH_TOKEN='<token>'`
 
 ## Notes
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -7,7 +7,7 @@ Step-by-step guide to using every MangroveTrader feature through the Claude Code
 - This plugin installed (see [Install](#install) below)
 - (Optional) A wallet with USDC on Base mainnet for paid tool testing (MetaMask, Phantom, or any EVM wallet)
 
-**Cost:** Free to use most features. Your own trade history is free. Paid tools (others' history, full leaderboard, search) cost $0.02-$1.25 USDC per query on Base.
+**Cost:** Free to use most features. Your own trade history is free. Paid tools (others' history, full leaderboard, search) cost $0.02-$0.25+ USDC per query on Base.
 
 ---
 
@@ -39,25 +39,54 @@ You should see all 13 commands listed. If you don't see `/mt-help`, the plugin d
 /mt-status
 ```
 
-**Expected:** API health (healthy/unhealthy), Twitter Agent status (alive/dead), and a list of all 12 plugin commands.
+**Expected:** API health (healthy/unhealthy), Twitter Agent status (alive/dead), and a list of all 13 plugin commands.
 
 **Pass criteria:**
 - [ ] API shows "healthy"
 - [ ] Twitter Agent shows "alive"
-- [ ] 12 commands listed in user-journey order
+- [ ] 13 commands listed in user-journey order
 - [ ] MCP endpoint shown: `https://api.mangrovetraders.com/mcp/`
 
 ---
 
-## Step 2: Look Up a Trader's Stats (Free)
+## Step 2: Verify Your X Identity
+
+```
+/mt-set-handle
+```
+
+Most free tools require a verified session token tied to your X (Twitter) account. This step authenticates you via X OAuth 2.0 so your handle cannot be spoofed.
+
+**Expected flow:**
+
+1. Plugin checks for `MT_AUTH_TOKEN` environment variable
+2. If not set: plugin calls `trader_login`, which returns a verification URL
+3. Open the URL in your browser and authenticate with X
+4. X redirects to the MangroveTrader callback, which issues a session token
+5. Plugin instructs you to set `MT_AUTH_TOKEN=<token>` in your environment:
+   - **macOS/zsh:** `export MT_AUTH_TOKEN=<token>` in `~/.zshenv`
+   - **Linux/bash:** `export MT_AUTH_TOKEN=<token>` in `~/.bashrc`
+   - **Windows:** `[System.Environment]::SetEnvironmentVariable('MT_AUTH_TOKEN', '<token>', 'User')`
+6. Run `/mt-set-handle` again — plugin confirms: "Verified as @{handle}."
+
+**If `MT_AUTH_TOKEN` is already set:** Plugin calls `trader_my_stats` to resolve and confirm your handle immediately.
+
+**Pass criteria:**
+- [ ] `trader_login` returns a valid X authorization URL
+- [ ] After authenticating, token resolves to your correct handle
+- [ ] "Verified as @{handle}" confirmation shown
+
+**Note:** The session token expires in 30 days. Re-run `/mt-set-handle` after re-authenticating.
+
+---
+
+## Step 3: Look Up Your Stats (Free)
 
 ```
 /mt-stats
 ```
 
-When prompted, enter a Twitter handle: `_jhthomas`
-
-**Expected:** The plugin calls `trader_my_stats` and shows:
+**Expected:** Plugin reads `MT_AUTH_TOKEN`, calls `trader_my_stats` with `auth_token`, and shows:
 - Composite score (0-100)
 - Rank (# among all traders)
 - Total trades
@@ -66,20 +95,21 @@ When prompted, enter a Twitter handle: `_jhthomas`
 
 **Pass criteria:**
 - [ ] MCP tool `trader_my_stats` was called (not a curl/REST fallback)
-- [ ] Response shows real data for the trader
+- [ ] `auth_token` was passed (no plain handle prompt)
+- [ ] Response shows real data for your account
 - [ ] If score is 0.0, that's normal -- scoring runs at midnight UTC
 
 ---
 
-## Step 3: Get a Performance Report (Free)
+## Step 4: Get a Performance Report (Free)
 
 ```
 /mt-report
 ```
 
-Enter handle: `_jhthomas`, timeframe: `30d`
+Enter timeframe: `30d`
 
-**Expected:** The plugin calls `trader_performance_report` and shows:
+**Expected:** Plugin reads `MT_AUTH_TOKEN`, calls `trader_performance_report` with `auth_token` and `timeframe`, and shows:
 - Composite score and rank
 - Total return %
 - Sharpe ratio (consistency)
@@ -89,12 +119,13 @@ Enter handle: `_jhthomas`, timeframe: `30d`
 
 **Pass criteria:**
 - [ ] MCP tool `trader_performance_report` was called
+- [ ] `auth_token` was passed (no plain handle prompt)
 - [ ] Timeframe reflected in response
 - [ ] Scoring weights shown
 
 ---
 
-## Step 4: Check Last Trade (Free)
+## Step 5: Check Any Trader's Last Trade (Free)
 
 ```
 /mt-last
@@ -102,19 +133,19 @@ Enter handle: `_jhthomas`, timeframe: `30d`
 
 Enter handle: `_jhthomas`
 
-**Expected:** The plugin calls `trader_last_trade` and shows:
+**Expected:** Plugin calls `trader_last_trade` (public — no auth required) and shows:
 - Most recent trade (action, symbol, quantity, price, timestamp)
 - Total trade count
-- Mention of `/mt-history` for full history (free for own trades)
+- Mention of `/mt-history` for full history
 
 **Pass criteria:**
 - [ ] MCP tool `trader_last_trade` was called
+- [ ] No auth token required — any handle works
 - [ ] Trade details shown
-- [ ] Upsell to paid history mentioned
 
 ---
 
-## Step 5: Compose a Trade Tweet
+## Step 6: Compose a Trade Tweet
 
 ```
 /mt-track
@@ -132,7 +163,7 @@ Follow the prompts: action (long), quantity (100), symbol (AAPL), price (185.50)
 
 ---
 
-## Step 6: View the Leaderboard (Paid -- $0.25+ USDC)
+## Step 7: View the Leaderboard (Paid -- $0.25+ USDC)
 
 ```
 /mt-leaderboard
@@ -178,7 +209,7 @@ The x402 payment flow works like this:
 
 ---
 
-## Step 7: Search for a Trader (Paid -- $0.02 USDC)
+## Step 8: Search for a Trader (Paid -- $0.02 USDC)
 
 ```
 /mt-search
@@ -195,16 +226,16 @@ Enter a search query (handle or name).
 
 ---
 
-## Step 8: View Trade History (Free for own, Paid for others)
+## Step 9: View Trade History (Free for own, Paid for others)
 
 ```
 /mt-history
 ```
 
-Enter handle: `_jhthomas`
+Enter handle: your own handle (for free access)
 
 **Own history (free):**
-- Plugin calls `trader_get_trade_history` with `requester_handle` matching your handle
+- Plugin reads `MT_AUTH_TOKEN` and calls `trader_get_trade_history` with `auth_token`
 - Data returns directly with `"access": "free"` — no payment needed
 
 **Others' history (paid, $0.01 per 3 trades):**
@@ -213,41 +244,41 @@ Enter handle: `_jhthomas`
 **Pass criteria:**
 - [ ] Own history returns data immediately (no PAYMENT_REQUIRED)
 - [ ] Own history response has `access: "free"`
+- [ ] `auth_token` used for free access (not plain handle matching)
 - [ ] Others' history shows PAYMENT_REQUIRED with computed price
 - [ ] Price formula: ceil(trades / 3) * $0.01
 - [ ] Full trade list returned if payment completed
 
 ---
 
-## Step 9: Cancel a Trade (Free)
+## Step 10: Cancel a Trade (Free)
 
 ```
 /mt-cancel
 ```
 
-Enter your Twitter handle.
-
-**Expected:** The plugin calls `trader_cancel_last`:
+**Expected:** Plugin reads `MT_AUTH_TOKEN`, calls `trader_cancel_last` with `auth_token`:
 - If you have a trade within the last 5 minutes: trade cancelled, details shown
 - If your last trade was more than 5 minutes ago: `CANCEL_WINDOW_EXPIRED` error with how long ago the trade was
 - If you have no trades: `NO_TRADES` error
 
 **Pass criteria:**
 - [ ] MCP tool `trader_cancel_last` was called
+- [ ] `auth_token` passed (no handle prompt)
 - [ ] 5-minute window enforced
 - [ ] Structured error for expired/no trades (no crash)
 
 ---
 
-## Step 10: Watch a Trader (Free)
+## Step 11: Watch a Trader (Free)
 
 ```
 /mt-watch
 ```
 
-Enter your handle and the target trader's handle.
+Enter the target trader's handle.
 
-**Expected:** The plugin calls `trader_watch`:
+**Expected:** Plugin reads `MT_AUTH_TOKEN`, calls `trader_watch` with `auth_token` and `target_handle`:
 - Success: "Now watching @target. You watch N trader(s)."
 - Plus a note: "Watchlist saved. Activity notifications for watched traders are coming soon."
 
@@ -255,6 +286,7 @@ Enter your handle and the target trader's handle.
 
 **Pass criteria:**
 - [ ] MCP tool `trader_watch` was called
+- [ ] `auth_token` passed (no watcher handle prompt)
 - [ ] Confirmation with watch count
 - [ ] "notifications coming soon" note present
 - [ ] Self-watch rejected with `SELF_WATCH` error
@@ -262,29 +294,30 @@ Enter your handle and the target trader's handle.
 
 ---
 
-## Step 11: Unwatch a Trader (Free)
+## Step 12: Unwatch a Trader (Free)
 
 ```
 /mt-unwatch
 ```
 
-Enter your handle and the target trader's handle.
+Enter the target trader's handle.
 
-**Expected:** "Stopped watching @target."
+**Expected:** Plugin reads `MT_AUTH_TOKEN`, calls `trader_unwatch` with `auth_token` and `target_handle`. Confirms: "Stopped watching @target."
 
 **Pass criteria:**
 - [ ] MCP tool `trader_unwatch` was called
+- [ ] `auth_token` passed (no handle prompt)
 - [ ] Confirmation shown
 
 ---
 
-## Step 12: List All Commands
+## Step 13: List All Commands
 
 ```
 /mt-help
 ```
 
-**Expected:** All 12 commands listed in user-journey order (trade, stats, report, history, leaderboard, search, manage, utility), with pricing for paid commands.
+**Expected:** All 13 commands listed in user-journey order (trade, stats, report, history, leaderboard, search, manage, utility), with pricing for paid commands.
 
 **Pass criteria:**
 - [ ] 13 commands shown
@@ -295,20 +328,20 @@ Enter your handle and the target trader's handle.
 
 ## Summary
 
-| # | Test | Command | MCP Tool | Cost |
-|---|------|---------|----------|------|
-| 1 | Server status | `/mt-status` | (health endpoint) | Free |
-| 2 | Trader stats | `/mt-stats` | `trader_my_stats` | Free |
-| 3 | Performance report | `/mt-report` | `trader_performance_report` | Free |
-| 4 | Last trade | `/mt-last` | `trader_last_trade` | Free |
-| 5 | Compose trade | `/mt-track` | (local only) | Free |
-| 6 | Leaderboard | `/mt-leaderboard` | `trader_get_leaderboard` | $0.25+ (top 5 free on Twitter) |
-| 7 | Search trader | `/mt-search` | `trader_search_trader` | $0.02 |
-| 8 | Trade history | `/mt-history` | `trader_get_trade_history` | Free (own) / $0.01/3 trades (others) |
-| 9 | Cancel trade | `/mt-cancel` | `trader_cancel_last` | Free |
-| 10 | Watch trader | `/mt-watch` | `trader_watch` | Free |
-| 11 | Unwatch trader | `/mt-unwatch` | `trader_unwatch` | Free |
-| 12 | Set handle | `/mt-set-handle` | (session only) | Free |
-| 13 | Help | `/mt-help` | (local only) | Free |
+| # | Test | Command | MCP Tool | Auth | Cost |
+|---|------|---------|----------|------|------|
+| 1 | Server status | `/mt-status` | (health endpoint) | None | Free |
+| 2 | Verify identity | `/mt-set-handle` | `trader_login` | X OAuth | Free |
+| 3 | Trader stats | `/mt-stats` | `trader_my_stats` | `auth_token` | Free |
+| 4 | Performance report | `/mt-report` | `trader_performance_report` | `auth_token` | Free |
+| 5 | Last trade | `/mt-last` | `trader_last_trade` | None | Free |
+| 6 | Compose trade | `/mt-track` | (local only) | None | Free |
+| 7 | Leaderboard | `/mt-leaderboard` | `trader_get_leaderboard` | None | $0.25+ (top 5 free on Twitter) |
+| 8 | Search trader | `/mt-search` | `trader_search_trader` | None | $0.02 |
+| 9 | Trade history | `/mt-history` | `trader_get_trade_history` | `auth_token` (own) | Free (own) / $0.01/3 trades (others) |
+| 10 | Cancel trade | `/mt-cancel` | `trader_cancel_last` | `auth_token` | Free |
+| 11 | Watch trader | `/mt-watch` | `trader_watch` | `auth_token` | Free |
+| 12 | Unwatch trader | `/mt-unwatch` | `trader_unwatch` | `auth_token` | Free |
+| 13 | Help | `/mt-help` | (local only) | None | Free |
 
-**Total cost to test everything:** $0.28+ USDC (if you test all 3 paid tools with minimum params). Free tools cost nothing.
+**Total cost to test everything:** $0.27+ USDC (if you test all 3 paid tools with minimum params). Free tools cost nothing.

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "MangroveTrader context hook — injects plugin context on each prompt",
+  "description": "MangroveTrader context hook — injects plugin context on each prompt, auto-pays x402 tool calls",
   "hooks": {
     "UserPromptSubmit": [
       {
@@ -8,6 +8,18 @@
             "type": "command",
             "command": "echo '{\"hookSpecificOutput\":{\"suppressOutput\":true,\"additionalContext\":\"MangroveTrader plugin active. If the user has set their handle via /mt-set-handle, use it for all commands that need twitter_handle or requester_handle. Commands: /mt-track (compose trade), /mt-stats [handle] (free), /mt-report [handle] [timeframe] (free), /mt-last [handle] (free), /mt-history [handle] [limit] (own free, others $0.01/3 trades x402), /mt-leaderboard [timeframe] [limit] ($0.25+ x402, top 5 free on Twitter), /mt-search <query> ($0.02 x402), /mt-cancel [handle] (free, 5-min window), /mt-watch [handle] <target> (free), /mt-unwatch [handle] <target> (free), /mt-set-handle <handle> (set your Twitter handle), /mt-status, /mt-help. MCP server: mangrove-trader at https://api.mangrovetraders.com/mcp/. REST fallback: https://api.mangrovetraders.com/api/v1/. Website: mangrovetraders.com. Trades are logged by tweeting to @MangroveTrader on Twitter.\"}}'",
             "timeout": 5
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "mcp__mangrove-trader__*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/x402_signer.py\"",
+            "timeout": 30
           }
         ]
       }

--- a/hooks/x402_signer.py
+++ b/hooks/x402_signer.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""x402 auto-pay hook for MangroveTrader MCP tools.
+
+PostToolUse hook. When an x402-gated MCP tool returns PAYMENT_REQUIRED,
+this script signs the payment and retries via the REST API, injecting
+the real result as context so Claude doesn't need to re-invoke the tool.
+
+Required:
+  MT_WALLET_PRIVATE_KEY   EVM private key (hex, with or without 0x prefix)
+
+Optional:
+  MT_API_BASE_URL         API base URL (default: https://api.mangrovetraders.com)
+  MT_MAX_PAYMENT_USD      Max USDC to auto-sign per request (default: 0.30)
+
+Install dependencies:
+  pip install "x402[evm]" eth-account httpx
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+
+# Redirect all library logging to stderr so stdout stays clean for hook JSON output
+logging.basicConfig(stream=sys.stderr)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("httpcore").setLevel(logging.WARNING)
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+# Short tool names (after stripping MCP prefix) that require x402 payment
+X402_TOOLS = frozenset({
+    "trader_get_leaderboard",
+    "trader_search_trader",
+    "trader_get_trade_history",
+})
+
+REST_BASE = os.environ.get("MT_API_BASE_URL", "https://api.mangrovetraders.com")
+MAX_PAYMENT_USD = float(os.environ.get("MT_MAX_PAYMENT_USD", "0.30"))
+
+# Maps MCP tool name -> REST endpoint config
+TOOL_CONFIG = {                                                                                                                               
+    "trader_get_leaderboard": {                                                                                                               
+        "path": "/api/x402/leaderboard",                                                                                                      
+        "payment_header": "payment-signature",                                                                                                        
+    },                                                                                                                                        
+    "trader_search_trader": {                                                                                                                 
+        "path": "/api/x402/search",                                                                                                           
+        "payment_header": "payment-signature",                                                                                                        
+    },                                                                                                                                        
+    "trader_get_trade_history": {                                                                                                             
+        "path": "/api/x402/trade_history",                                                                                                    
+        "payment_header": "X-Payment",                                                                                                        
+    },                                                                                                                                        
+}   
+
+
+# ---------------------------------------------------------------------------
+# Signer (mirrors EthAccountSigner in e2e_payment_test.py)
+# eth-account 0.13+ requires full_message dict format for sign_typed_data
+# ---------------------------------------------------------------------------
+
+class _EthAccountSigner:
+    def __init__(self, private_key: str):
+        from eth_account import Account
+        if not private_key.startswith("0x"):
+            private_key = "0x" + private_key
+        self.account = Account.from_key(private_key)
+        self.address = self.account.address
+
+    def sign_typed_data(self, domain, types, primary_type, message) -> bytes:
+        domain_dict = {
+            "name": domain.name,
+            "version": domain.version,
+            "chainId": domain.chain_id,
+            "verifyingContract": domain.verifying_contract,
+        }
+        domain_dict = {k: v for k, v in domain_dict.items() if v is not None}
+        if hasattr(domain, "salt") and domain.salt is not None:
+            domain_dict["salt"] = domain.salt
+
+        types_dict = {}
+        for type_name, fields in types.items():
+            types_dict[type_name] = [{"name": f.name, "type": f.type} for f in fields]
+
+        full_message = {
+            "types": types_dict,
+            "primaryType": primary_type,
+            "domain": domain_dict,
+            "message": dict(message),
+        }
+        signed = self.account.sign_typed_data(full_message=full_message)
+        return signed.signature
+
+
+# ---------------------------------------------------------------------------
+# REST body builder — maps MCP tool input to REST request body
+# ---------------------------------------------------------------------------
+
+def _build_rest_body(tool_name: str, tool_input: dict) -> dict:
+    if tool_name == "trader_get_leaderboard":
+        body = {}
+        if "timeframe" in tool_input:
+            body["timeframe"] = tool_input["timeframe"]
+        if "limit" in tool_input:
+            body["limit"] = tool_input["limit"]
+        return body
+
+    if tool_name == "trader_search_trader":
+        # MCP uses "query"; REST uses "twitter_handle"
+        return {
+            "twitter_handle": tool_input.get("query", ""),
+            "limit": tool_input.get("limit", 20),
+        }
+
+    if tool_name == "trader_get_trade_history":
+        body = {"twitter_handle": tool_input.get("twitter_handle", "")}
+        if tool_input.get("limit"):
+            body["limit"] = tool_input["limit"]
+        return body
+
+    return {}
+
+
+# ---------------------------------------------------------------------------
+# Price parsing
+# ---------------------------------------------------------------------------
+
+def _parse_price(price_str: str) -> float:
+    """'$0.25' -> 0.25"""
+    return float(str(price_str).lstrip("$"))
+
+
+# ---------------------------------------------------------------------------
+# Core async signing + REST call
+# ---------------------------------------------------------------------------
+
+async def _sign_and_call(
+    payment_required_b64: str,
+    tool_name: str,
+    tool_input: dict,
+    private_key: str,
+) -> dict:
+    from x402 import x402Client
+    from x402.http.utils import decode_payment_required_header, encode_payment_signature_header
+    from x402.mechanisms.evm.exact import register_exact_evm_client
+    import httpx
+
+    signer = _EthAccountSigner(private_key)
+    client = x402Client()
+    register_exact_evm_client(client, signer)
+
+    payment_required = decode_payment_required_header(payment_required_b64)
+    payload = await client.create_payment_payload(payment_required)
+    signed_payment = encode_payment_signature_header(payload)
+
+    cfg = TOOL_CONFIG[tool_name]
+    body = _build_rest_body(tool_name, tool_input)
+    headers = {
+        "Content-Type": "application/json",
+        cfg["payment_header"]: signed_payment,
+    }
+
+    async with httpx.AsyncClient(timeout=20.0) as http:
+        resp = await http.post(f"{REST_BASE}{cfg['path']}", json=body, headers=headers)
+        resp.raise_for_status()
+        return resp.json()
+
+
+# ---------------------------------------------------------------------------
+# Hook entrypoint
+# ---------------------------------------------------------------------------
+
+def main():
+    raw = sys.stdin.read().strip()
+    if not raw:
+        sys.exit(0)
+
+    try:
+        event = json.loads(raw)
+    except json.JSONDecodeError:
+        sys.exit(0)
+
+    raw_tool_name = event.get("tool_name", "")
+    # Strip MCP server prefix: "mcp__mangrove-trader__trader_get_leaderboard" -> "trader_get_leaderboard"
+    tool_name = raw_tool_name.split("__")[-1]
+    if tool_name not in X402_TOOLS:
+        sys.exit(0)
+
+    # Parse tool response (may be a JSON string or already a dict)
+    tool_response = event.get("tool_response", "")
+    if isinstance(tool_response, str):
+        try:
+            response_data = json.loads(tool_response)
+        except (json.JSONDecodeError, ValueError):
+            sys.exit(0)
+    else:
+        response_data = tool_response
+
+    if not isinstance(response_data, dict):
+        sys.exit(0)
+
+    # Unwrap MCP envelope: {"result": "<json string>"} -> inner dict
+    if "result" in response_data and "code" not in response_data:
+        inner = response_data["result"]
+        if isinstance(inner, str):
+            try:
+                response_data = json.loads(inner)
+            except (json.JSONDecodeError, ValueError):
+                sys.exit(0)
+        elif isinstance(inner, dict):
+            response_data = inner
+
+    if response_data.get("code") != "PAYMENT_REQUIRED":
+        sys.exit(0)
+
+    # Validate price against cap before touching the wallet
+    price_str = response_data.get("price", "$0.00")
+    try:
+        price = _parse_price(price_str)
+    except (ValueError, TypeError):
+        _output_context(f"[x402] Could not parse price '{price_str}'. Not signing.")
+        sys.exit(0)
+
+    if price > MAX_PAYMENT_USD:
+        _output_context(
+            f"[x402] Refused: server requested {price_str} USDC "
+            f"which exceeds the auto-pay cap of ${MAX_PAYMENT_USD:.2f}. "
+            f"Set MT_MAX_PAYMENT_USD to a higher value to allow this, "
+            f"or pay manually."
+        )
+        sys.exit(0)
+
+    private_key = os.environ.get("MT_WALLET_PRIVATE_KEY", "").strip()
+    if not private_key:
+        _output_context(
+            "[x402] MT_WALLET_PRIVATE_KEY is not set — cannot auto-sign payment.\n"
+            "To enable auto-pay for paid tools, add to ~/.zshenv (not ~/.zshrc):\n\n"
+            "  export MT_WALLET_PRIVATE_KEY=<your-evm-private-key-hex>\n\n"
+            "The wallet must hold USDC on Base. Restart Claude Code after setting."
+        )
+        sys.exit(0)
+
+    payment_required_b64 = response_data.get("payment_required", "")
+    if not payment_required_b64:
+        sys.exit(0)
+
+    tool_input = event.get("tool_input", {})
+    if isinstance(tool_input, str):
+        try:
+            tool_input = json.loads(tool_input)
+        except (json.JSONDecodeError, ValueError):
+            tool_input = {}
+
+    try:
+        signer = _EthAccountSigner(private_key)
+        wallet_address = signer.address
+        result = asyncio.run(_sign_and_call(payment_required_b64, tool_name, tool_input, private_key))
+    except Exception as e:
+        _output_context(
+            f"[x402] Payment attempt failed: {e}\n"
+            f"The PAYMENT_REQUIRED response above stands. You may retry manually."
+        )
+        sys.exit(0)
+
+    _output_context(
+        f"[x402] Auto-paid {price_str} USDC from {wallet_address}.\n"
+        f"Ignore the PAYMENT_REQUIRED above — the payment succeeded. "
+        f"Present this result to the user:\n\n"
+        + json.dumps(result, indent=2, default=str)
+    )
+
+
+def _output_context(message: str):
+    print(json.dumps({
+        "suppressOutput": True,
+        "hookSpecificOutput": {
+            "hookEventName": "PostToolUse",
+            "additionalContext": message,
+        }
+    }))
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/mangrove-trader/SKILL.md
+++ b/skills/mangrove-trader/SKILL.md
@@ -13,7 +13,7 @@ version: 2.0.0
 
 Social trading leaderboard. Traders tweet to **@MangroveTrader** on Twitter, a Grok-powered agent parses trades, tracks positions against real market data, computes scoring metrics, and exposes rankings.
 
-**9 MCP tools** -- 6 free, 3 paid via x402 (USDC on Base).
+**10 MCP tools** -- 7 free, 3 paid via x402 (USDC on Base).
 **13 commands** -- all prefixed with `/mt-`.
 
 ---
@@ -56,27 +56,40 @@ Trades are submitted by tweeting to @MangroveTrader on Twitter. Use `/mt-track` 
 
 ---
 
+## Authentication
+
+Most free tools require identity verification via X OAuth 2.0. Check `MT_AUTH_TOKEN` env var first — if set, pass it as `auth_token`. If not set, call `trader_login` to get a verification URL.
+
+**Tool:** `trader_login` (no params)
+- Returns a URL — user opens it in a browser, authenticates with X, receives a token
+- User sets `MT_AUTH_TOKEN=<token>` in their environment (persists for 30 days)
+- Use `/mt-set-handle` to walk the user through this flow
+
+---
+
 ## Free Tools
 
 ### My Stats -- `/mt-stats`
 
 **Tool:** `trader_my_stats`
 
-1. Call with `twitter_handle`
-2. Returns: composite_score, rank, total_trades, qualified, open_positions
+1. Check `MT_AUTH_TOKEN` env var. If set, pass as `auth_token`. If not, call `trader_login` and stop.
+2. Call with `auth_token` (optional `twitter_handle` to verify the token matches a specific handle)
+3. Returns: composite_score, rank, total_trades, qualified, open_positions
 
 ### Performance Report -- `/mt-report`
 
 **Tool:** `trader_performance_report`
 
-1. Call with `twitter_handle` and `timeframe` (daily/weekly/monthly/all_time/30d/7d, default: 30d)
-2. Returns: composite_score, rank, total_return_pct, sharpe_ratio, max_drawdown_pct, win_rate, trade_count
+1. Check `MT_AUTH_TOKEN` env var. If set, pass as `auth_token`. If not, call `trader_login` and stop.
+2. Call with `auth_token` and `timeframe` (daily/weekly/monthly/all_time/30d/7d, default: all_time)
+3. Returns: composite_score, rank, total_return_pct, sharpe_ratio, max_drawdown_pct, win_rate, trade_count
 
 ### Last Trade -- `/mt-last`
 
 **Tool:** `trader_last_trade`
 
-1. Call with `twitter_handle`
+1. Call with `twitter_handle` (public — no auth required)
 2. Returns: action, symbol, asset_class, quantity, price, created_at, total_trades
 
 ---
@@ -112,8 +125,8 @@ All paid tools follow the x402 payment protocol. See [Payment Flow](#x402-paymen
 **Tool:** `trader_get_trade_history` -- Free (own) / $0.01 per 3 trades (others) USDC on Base
 
 **Own history (free):**
-1. Call with `twitter_handle` AND `requester_handle` set to the user's own handle
-2. Data returns directly with `"access": "free"` -- no payment needed
+1. Check `MT_AUTH_TOKEN` env var. If set, call with `twitter_handle` AND `auth_token` — data returns directly with `"access": "free"`.
+2. Legacy fallback: `requester_handle` matching `twitter_handle` also grants free access.
 
 **Others' history (paid):**
 1. Call WITHOUT `payment` (include `twitter_handle`, optional `limit`)
@@ -180,17 +193,18 @@ Traders must close a minimum number of trades to qualify for scoring and the lea
 
 ## Tool Quick Reference
 
-| Tool | Access | Price | Description |
-|------|--------|-------|-------------|
-| `trader_my_stats` | Free | -- | Score, rank, open positions |
-| `trader_performance_report` | Free | -- | Detailed scoring breakdown |
-| `trader_last_trade` | Free | -- | Most recent trade + total count |
-| `trader_get_leaderboard` | x402 | $0.25+ | Full rankings. Top 5 free on Twitter. |
-| `trader_search_trader` | x402 | $0.02 | Look up any trader by name/handle |
-| `trader_get_trade_history` | Free / x402 | Free (own) / $0.01/3 (others) | Trade log. Pass `requester_handle` for free own history. |
-| `trader_cancel_last` | Free | -- | Cancel most recent trade |
-| `trader_watch` | Free | -- | Watch a trader |
-| `trader_unwatch` | Free | -- | Unwatch a trader |
+| Tool | Access | Price | Auth | Description |
+|------|--------|-------|------|-------------|
+| `trader_login` | Free | -- | None | Start X OAuth 2.0 — returns verification URL |
+| `trader_my_stats` | Free | -- | `auth_token` required | Score, rank, open positions |
+| `trader_performance_report` | Free | -- | `auth_token` required | Detailed scoring breakdown |
+| `trader_last_trade` | Free | -- | None | Most recent trade + total count (public) |
+| `trader_get_leaderboard` | x402 | $0.25+ | None | Full rankings. Top 5 free on Twitter. |
+| `trader_search_trader` | x402 | $0.02 | None | Look up any trader by name/handle |
+| `trader_get_trade_history` | Free / x402 | Free (own) / $0.01/3 (others) | `auth_token` for free own history | Trade log |
+| `trader_cancel_last` | Free | -- | `auth_token` required | Cancel most recent trade |
+| `trader_watch` | Free | -- | `auth_token` required | Watch a trader |
+| `trader_unwatch` | Free | -- | `auth_token` required | Unwatch a trader |
 
 ---
 


### PR DESCRIPTION
Add x402_signer.py PostToolUse hook that automatically signs and pays for paid MCP tools (leaderboard, search, trade history) using an EVM wallet. Update hooks.json, commands, SKILL.md, README, and user guide to document the x402 payment flow and new signing capability.