### PR TITLE
docs: avoid wallet private key requests

### DIFF
--- a/commands/mt-history.md
+++ b/commands/mt-history.md
@@ -15,11 +15,7 @@ View a trader's complete trade history. Your own history is free.
 4. **If looking up someone else's history**: call `trader_get_trade_history` WITHOUT `payment` parameter first. Server returns PAYMENT_REQUIRED with total trades and computed price.
 5. Present: "X trades available, cost is $Y USDC. Proceed?"
 6. **If payment capability available**: sign x402 payment, call again WITH `payment`, present trade list (action, symbol, asset class, quantity, price, timestamp)
-7. **If no payment capability**: tell the user this tool requires x402 payment signing with an EVM wallet holding USDC on Base. Ask them to provide their EVM wallet private key. Once provided, persist it for future sessions using the platform-appropriate method, then set it in the current session and retry from step 4:
-   - **macOS**: append `export MT_WALLET_PRIVATE_KEY=<key>` to `~/.zshenv`
-   - **Linux**: append `export MT_WALLET_PRIVATE_KEY=<key>` to `~/.bashrc` (or `~/.profile` for login shells)
-   - **Windows (PowerShell)**: run `[System.Environment]::SetEnvironmentVariable('MT_WALLET_PRIVATE_KEY', '<key>', 'User')` to persist at user level; also set in current session with `$env:MT_WALLET_PRIVATE_KEY='<key>'`
-   - If the user does not have a wallet, suggest `/mt-last` (free, shows most recent trade only) or the REST API with an API key
+7. **If no payment capability**: tell the user this tool requires x402 payment signing with an EVM wallet holding USDC on Base. Do not ask the user to paste or disclose a wallet private key. Instead, direct them to configure wallet signing outside the chat session, then retry from step 4 after payment capability is available. If they do not have wallet signing, suggest `/mt-last` (free, shows most recent trade only) or the REST API with an API key.
 
 ## Pricing
 

--- a/commands/mt-leaderboard.md
+++ b/commands/mt-leaderboard.md
@@ -26,11 +26,7 @@ This is an x402 paid tool. The agent or user must pay in USDC on Base to access 
    - Sign the payment using the x402 protocol against the requirements
    - Call `trader_get_leaderboard` again WITH the signed `payment` parameter
    - Present the leaderboard: rank, handle, score, return %
-7. **If no payment capability**: tell the user this tool requires x402 payment signing with an EVM wallet holding USDC on Base. Ask them to provide their EVM wallet private key. Once provided, persist it for future sessions using the platform-appropriate method, then set it in the current session and retry from step 3:
-   - **macOS**: append `export MT_WALLET_PRIVATE_KEY=<key>` to `~/.zshenv`
-   - **Linux**: append `export MT_WALLET_PRIVATE_KEY=<key>` to `~/.bashrc` (or `~/.profile` for login shells)
-   - **Windows (PowerShell)**: run `[System.Environment]::SetEnvironmentVariable('MT_WALLET_PRIVATE_KEY', '<key>', 'User')` to persist at user level; also set in current session with `$env:MT_WALLET_PRIVATE_KEY='<key>'`
-   - If the user does not have a wallet, suggest alternatives:
+7. **If no payment capability**: tell the user this tool requires x402 payment signing with an EVM wallet holding USDC on Base. Do not ask the user to paste or disclose a wallet private key. Instead, direct them to configure wallet signing outside the chat session, then retry from step 3 after payment capability is available. If they do not have wallet signing, suggest alternatives:
      - Own rank is always free via `/mt-stats`
      - Use the REST API at `https://api.mangrovetraders.com/api/x402/leaderboard` with an API key (X-API-Key header bypasses payment)
      - Daily top 10 posted on @MangroveTrader Twitter

--- a/commands/mt-search.md
+++ b/commands/mt-search.md
@@ -17,10 +17,7 @@ This is an x402 paid tool ($0.02 USDC on Base).
 4. Server returns PAYMENT_REQUIRED ($0.02 USDC).
 5. Present the price and ask to confirm.
 6. **If payment capability available**: sign x402 payment, call again WITH `payment`, present results (handle, display name, score, rank, trade count, qualified status).
-7. **If no payment capability**: tell the user this tool requires x402 payment signing with an EVM wallet holding USDC on Base. Ask them to provide their EVM wallet private key. Once provided, persist it for future sessions using the platform-appropriate method, then set it in the current session and retry from step 3:
-   - **macOS**: append `export MT_WALLET_PRIVATE_KEY=<key>` to `~/.zshenv`
-   - **Linux**: append `export MT_WALLET_PRIVATE_KEY=<key>` to `~/.bashrc` (or `~/.profile` for login shells)
-   - **Windows (PowerShell)**: run `[System.Environment]::SetEnvironmentVariable('MT_WALLET_PRIVATE_KEY', '<key>', 'User')` to persist at user level; also set in current session with `$env:MT_WALLET_PRIVATE_KEY='<key>'`
+7. **If no payment capability**: tell the user this tool requires x402 payment signing with an EVM wallet holding USDC on Base. Do not ask the user to paste or disclose a wallet private key. Instead, direct them to configure wallet signing outside the chat session, then retry from step 3 after payment capability is available. If they do not have wallet signing, suggest the REST API with an API key.
 
 ## Parameters
 


### PR DESCRIPTION
## Summary
- Stops paid command flows from asking users to paste wallet private keys into chat.
- Directs users to configure wallet signing outside the chat session before retrying x402 paid tools.
- Keeps the existing free alternatives and API-key paths intact.

## Validation
- git diff --check
- conflict-marker scan
- npx --yes markdown-link-check commands/mt-search.md commands/mt-history.md commands/mt-leaderboard.md --quiet

Note: a broader README link check found pre-existing broken README links for the Discord invite and MangroveTrader source/checklist URLs. This PR only changes the command docs above.