### PR TITLE
chore(hooks): stop injecting the command block on every prompt

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,17 +1,6 @@
 {
-  "description": "MangroveTrader context hook — injects plugin context on each prompt, auto-pays x402 tool calls",
+  "description": "MangroveTrader hooks — auto-pays x402 tool calls. The per-prompt context injection was removed: it re-stated the full command block on EVERY user message (pure recurring context load), and the /mt-* commands are already available from the plugin's commands without it.",
   "hooks": {
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "echo '{\"suppressOutput\":true,\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"MangroveTrader plugin active. If the user has set their handle via /mt-set-handle, use it for all commands that need twitter_handle or requester_handle. Commands: /mt-track (compose trade), /mt-stats [handle] (free), /mt-report [handle] [timeframe] (free), /mt-last [handle] (free), /mt-history [handle] [limit] (own free, others $0.01/3 trades x402), /mt-leaderboard [timeframe] [limit] ($0.25+ x402, top 5 free on Twitter), /mt-search <query> ($0.02 x402), /mt-cancel [handle] (free, 5-min window), /mt-watch [handle] <target> (free), /mt-unwatch [handle] <target> (free), /mt-set-handle <handle> (set your Twitter handle), /mt-status, /mt-help. MCP server: mangrove-trader at https://api.mangrovetraders.com/mcp/. REST fallback: https://api.mangrovetraders.com/api/v1/. Website: mangrovetraders.com. Trades are logged by tweeting to @MangroveTrader on Twitter.\"}}'",
-            "timeout": 5
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
       {
         "matcher": "mcp__mangrove-trader__*",


### PR DESCRIPTION
The plugin's `UserPromptSubmit` hook `echo`s MangroveTrader's entire command block into context on **every user message** — pure recurring per-turn context load. The `/mt-*` commands are already provided by the plugin's `commands/`, so the injection is redundant. This removes the `UserPromptSubmit` hook and **keeps** the `PostToolUse` x402 auto-pay hook (functional).

Note: the "Duplicate hooks file" error seen in `/plugin` is NOT from main — it's from a local uncommitted edit that added `"hooks": "./hooks/hooks.json"` to `plugin.json` (main has no such field; `hooks/hooks.json` auto-loads). That's separate and local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)