### PR TITLE
feat(plugin): /mt-submit — direct trade submission command

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [MangroveTrader](https://mangrovetraders.com) is a social trading leaderboard where traders post trades on Twitter, positions are tracked against real market data, and performance is scored daily.
 
-This plugin connects Claude Code to the MangroveTrader MCP server, giving you 13 slash commands and 10 MCP tools for stats, leaderboard, trade history, and more.
+This plugin connects Claude Code to the MangroveTrader MCP server, giving you 14 slash commands and 11 MCP tools for submitting trades, stats, leaderboard, trade history, and more.
 
 **Website:** [mangrovetraders.com](https://mangrovetraders.com)
 **Twitter:** [@MangroveTrader](https://twitter.com/MangroveTrader)
@@ -30,6 +30,7 @@ All commands are prefixed with `/mt-`:
 | Command | Description | Access |
 |---------|-------------|--------|
 | `/mt-track` | Compose a trade tweet | Free |
+| `/mt-submit` | Submit a trade directly (no tweet) | 3/day free, then $0.02 USDC |
 | `/mt-stats` | Your score, rank, open positions | Free |
 | `/mt-report` | Performance breakdown (return, Sharpe, drawdown) | Free |
 | `/mt-last` | Most recent trade and total count | Free |
@@ -45,11 +46,12 @@ All commands are prefixed with `/mt-`:
 
 ## MCP Tools
 
-The plugin connects to MangroveTrader's MCP server at `https://api.mangrovetraders.com/mcp/`. 10 tools available:
+The plugin connects to MangroveTrader's MCP server at `https://api.mangrovetraders.com/mcp/`. 11 tools available:
 
 | Tool | Access | Price | Notes |
 |------|--------|-------|-------|
 | `trader_login` | Free | -- | Start X OAuth 2.0 — returns a verification URL |
+| `trader_submit_trade` | Free / x402 | 3/day free, then $0.02 USDC | Enter/exit a position directly — no tweet |
 | `trader_my_stats` | Free | -- | Requires `auth_token` (MT_AUTH_TOKEN) |
 | `trader_performance_report` | Free | -- | Requires `auth_token` |
 | `trader_last_trade` | Free | -- | Public — accepts any `twitter_handle` |
@@ -66,6 +68,8 @@ The plugin connects to MangroveTrader's MCP server at `https://api.mangrovetrade
 2. A Grok-powered agent parses your trade and tracks the position
 3. Positions are marked-to-market against real prices every 5 minutes
 4. Scoring runs daily at midnight UTC
+
+Agents (and humans' agents) can also submit trades **directly** with `/mt-submit` / the `trader_submit_trade` tool — no tweet required (3/day free, then $0.02 USDC).
 
 ### Tweet Format
 

--- a/commands/mt-submit.md
+++ b/commands/mt-submit.md
@@ -1,0 +1,30 @@
+---
+name: mt-submit
+description: Submit a trade directly to MangroveTrader — no tweet required (3/day free, then $0.02)
+---
+
+# mt-submit
+
+Enter or exit a position on MangroveTrader **directly** — no tweet to @MangroveTrader needed.
+
+## Steps
+
+1. Check the `MT_AUTH_TOKEN` environment variable. If set, use it as `auth_token`.
+2. If `MT_AUTH_TOKEN` is not set, call `trader_login` to get a verification URL and stop — a verified X handle is required.
+3. Collect the trade if not already provided:
+   - **action**: `enter_long`, `enter_short`, `exit_long`, `exit_short` (shortcuts: long, short, sell, cover)
+   - **symbol**: ticker (BTC, AAPL, ES, ...)
+   - **price**: execution price — **required** for both entries and exits
+   - **quantity**: units (default 1)
+   - Options only: **strike_price**, **option_type** (`C`/`P`), **expiry_date** (`YYYY-MM-DD`)
+4. Call the `trader_submit_trade` MCP tool with `auth_token` + the trade params.
+5. **If the MCP tool is unavailable**, fall back to REST:
+   `POST https://api.mangrovetraders.com/api/v1/trader/submit_trade` with the JSON body.
+6. **Free tier:** the first 3 submissions/day are free — surface `free_trades_remaining_today`.
+7. **Past the free tier:** the tool returns `PAYMENT_REQUIRED` at **$0.02 USDC (Base)**. If `MT_WALLET_PRIVATE_KEY` is set, the x402 auto-pay hook signs it automatically; otherwise present the price and payment requirement. **Never ask for a private key in chat** (the plugin hook blocks it).
+8. Present the result: `status` (recorded), the position outcome (opened / averaged / closed / partial_exit), and remaining free trades.
+
+## Notes
+- Requires a verified X handle (via `trader_login`) — v1 keys the leaderboard on your Twitter handle.
+- A rejected trade (e.g. exit with no open position) is **not** charged and does **not** count against your free tier.
+- Prefer to log a trade via Twitter instead? Use `/mt-track` to compose the tweet.


### PR DESCRIPTION
Adds the **`/mt-submit`** slash command so a user (or their agent) can enter/exit a position **directly** — no tweet to @MangroveTrader.

## What
- `commands/mt-submit.md`: collects action/symbol/price/quantity (+ options fields), calls the new `trader_submit_trade` MCP tool, with a REST fallback (`POST /api/v1/trader/submit_trade`). Surfaces the free tier + x402 overage; never asks for a private key in chat (the `block-wallet-secrets` hook blocks it).
- README: 13→14 commands, 10→11 MCP tools, rows for `/mt-submit` + `trader_submit_trade`, and a "submit directly" note.

## Gating / dependencies (do not merge yet)
- **Requires the server tool** from https://github.com/MangroveTechnologies/MangroveTrader/pull/122 (`trader_submit_trade`) to exist — merge/deploy that first.
- **CI** across the org is blocked by the expired GH_PAT (https://github.com/MangroveTechnologies/mangrove-trader-plugin/issues — see MangroveTrader #121).
- **Version bump required on merge:** I deliberately did **not** bump `plugin.json`/`marketplace.json` here to avoid a conflict with PR #22's `2.0.5 → 2.1.0` bump. When this and #22 land, bump the version once (e.g. `2.2.0`) so the plugin cache refreshes and `/mt-submit` loads.

Pricing/behavior matches MangroveTrader #119 and the site copy in MangroveTrader #120.